### PR TITLE
Allow fields with underscores

### DIFF
--- a/src/AbstractAbstractFactory.php
+++ b/src/AbstractAbstractFactory.php
@@ -90,4 +90,37 @@ abstract class AbstractAbstractFactory
 
         return $graphQLType;
     }
+
+    /**
+     * In order to support fields with underscores we need to know
+     * if the possible filter name we found as the last _part of the
+     * filter field name is indeed a filter else it could be a field
+     *     e.g. id_name filter resolves to 'name' and is not a filter
+     *     e.g. id_eq filter resolves to 'eq' and is a filter
+     */
+    public function isFilter($filterName)
+    {
+        switch (strtolower($filterName)) {
+            case 'eq':
+            case 'neq':
+            case 'gt':
+            case 'lt':
+            case 'gte':
+            case 'lte':
+            case 'in':
+            case 'notin':
+            case 'between':
+            case 'contains':
+            case 'startswith':
+            case 'endswith':
+            case 'memberof':
+            case 'isnull':
+            case 'sort':
+            case 'distinct':
+                return true;
+            default:
+        }
+
+        return false;
+    }
 }

--- a/src/Resolve/EntityResolveAbstractFactory.php
+++ b/src/Resolve/EntityResolveAbstractFactory.php
@@ -165,16 +165,17 @@ final class EntityResolveAbstractFactory extends AbstractAbstractFactory impleme
                 }
 
                 // Handle most fields as $field_$type: $value
-                if (! strstr($field, '_')) {
+                // Get right-most _text
+                $filter = substr($field, strrpos($field, '_') + 1);
+                if (strpos($field, '_') === false || ! $this->isFilter($filter)) {
                     // Handle field:value
                      $filterArray[] = [
                          'type' => 'eq',
                          'field' => $field,
                          'value' => $value,
                      ];
-                } else {
-                    $field = strtok($field, '_');
-                    $filter = strtok('_');
+                } elseif (strpos($field, '_') !== false && $this->isFilter($filter)) {
+                    $field = substr($field, 0, strrpos($field, '_'));
 
                     switch ($filter) {
                         case 'sort':

--- a/src/Type/EntityTypeAbstractFactory.php
+++ b/src/Type/EntityTypeAbstractFactory.php
@@ -156,15 +156,19 @@ final class EntityTypeAbstractFactory extends AbstractAbstractFactory implements
                                                 continue;
                                             }
 
-                                            if (! strstr($field, '_')) {
-                                                $filterArray[] = [
-                                                    'type' => 'eq',
-                                                    'field' => $field,
-                                                    'value' => $value,
-                                                ];
-                                            } else {
-                                                $field = strtok($field, '_');
-                                                $filter = strtok('_');
+
+                                            // Handle most fields as $field_$type: $value
+                                            // Get right-most _text
+                                            $filter = substr($field, strrpos($field, '_') + 1);
+                                            if (strpos($field, '_') === false || ! $this->isFilter($filter)) {
+                                                // Handle field:value
+                                                 $filterArray[] = [
+                                                     'type' => 'eq',
+                                                     'field' => $field,
+                                                     'value' => $value,
+                                                 ];
+                                            } elseif (strpos($field, '_') !== false && $this->isFilter($filter)) {
+                                                $field = substr($field, 0, strrpos($field, '_'));
 
                                                 switch ($filter) {
                                                     case 'sort':


### PR DESCRIPTION
First coding of field_filter allowed for only a single underscore.  Now field names are evaluated from the last underscore and compared against a list of known filters.